### PR TITLE
Fix empty session check

### DIFF
--- a/dssr_select.py
+++ b/dssr_select.py
@@ -98,8 +98,9 @@ def run_dssr_json(pdb_path, exe):
         raise CmdException('DSSR failed (rc=%s). stderr tail: %s' % (str(rc), _safe_tail(err_txt)))
 
     if not out_txt.strip():
-        raise CmdException('DSSR returned empty stdout (expected JSON). stderr tail: %s' % _safe_tail(err_txt))
-
+        print("No structure loaded. Please load a PDB.CIF file before running DSSR-PyMOL.")
+        while not out_txt.strip():
+            pass
     try:
         return json.loads(out_txt)
     except Exception:

--- a/dssr_select.py
+++ b/dssr_select.py
@@ -98,9 +98,11 @@ def run_dssr_json(pdb_path, exe):
         raise CmdException('DSSR failed (rc=%s). stderr tail: %s' % (str(rc), _safe_tail(err_txt)))
 
     if not out_txt.strip():
-        print("No structure loaded. Please load a PDB.CIF file before running DSSR-PyMOL.")
+        print("No structure loaded. Please load a PDB/CIF file before running DSSR-PyMOL.")
         while not out_txt.strip():
             pass
+            return None 
+
     try:
         return json.loads(out_txt)
     except Exception:
@@ -1914,7 +1916,10 @@ class _DSSRGuiDialog(QtWidgets.QDialog if QtWidgets else object):
             self.list_widget.clear()
             self.list_widget.addItem('ERROR: %s' % str(e))
             try:
-                print('dssr_gui error: %s' % str(e))
+                if "NoneType" in str(e):
+                    print("")
+                else:
+                    print('dssr_gui error: %s' % str(e))
             except Exception:
                 pass
 
@@ -2155,3 +2160,4 @@ try:
     print('Loaded DSSR helper %s from: %s' % (__DSSR_PLUGIN_VERSION__, __file__))
 except Exception:
     pass
+

--- a/dssr_select.py
+++ b/dssr_select.py
@@ -98,10 +98,7 @@ def run_dssr_json(pdb_path, exe):
         raise CmdException('DSSR failed (rc=%s). stderr tail: %s' % (str(rc), _safe_tail(err_txt)))
 
     if not out_txt.strip():
-        print("No structure loaded. Please load a PDB/CIF file before running DSSR-PyMOL.")
-        while not out_txt.strip():
-            pass
-            return None 
+        raise CmdException('DSSR returned empty stdout (expected JSON). stderr tail: %s' % _safe_tail(err_txt))
 
     try:
         return json.loads(out_txt)
@@ -1916,10 +1913,7 @@ class _DSSRGuiDialog(QtWidgets.QDialog if QtWidgets else object):
             self.list_widget.clear()
             self.list_widget.addItem('ERROR: %s' % str(e))
             try:
-                if "NoneType" in str(e):
-                    print("")
-                else:
-                    print('dssr_gui error: %s' % str(e))
+                print('dssr_gui error: %s' % str(e))
             except Exception:
                 pass
 
@@ -2136,6 +2130,10 @@ def dssr_gui():
     global _DSSR_GUI_DIALOG
     if QtWidgets is None or QtCore is None:
         raise CmdException('Qt is not available in this PyMOL build')
+    
+    if not cmd.get_object_list():
+        print("No structure loaded. Please load a PDB.CIF file before running DSSR-PyMOL")
+        return
     if _DSSR_GUI_DIALOG is None:
         _DSSR_GUI_DIALOG = _DSSRGuiDialog()
     _DSSR_GUI_DIALOG.show()
@@ -2160,4 +2158,3 @@ try:
     print('Loaded DSSR helper %s from: %s' % (__DSSR_PLUGIN_VERSION__, __file__))
 except Exception:
     pass
-

--- a/dssr_select.py
+++ b/dssr_select.py
@@ -799,7 +799,7 @@ def dssr_select(selection='all',
     feature = unquote(feature).lower().strip()
 
     user_color = _resolve_color_spec(unquote(color).strip())
-                       
+
     if feature in ('features', 'help'):
         keys = sorted(FEATURE_MAP.keys())
         print('Supported features: ' + ', '.join(keys))
@@ -1867,6 +1867,14 @@ class _DSSRGuiDialog(QtWidgets.QDialog if QtWidgets else object):
         self._big_object_warning(sel)
 
         self.list_widget.clear()
+
+        # Bug Fix: If there is no structure loaded in PyMOL, do not trigger DSSR or update with loading status.
+        if not cmd.get_object_list():
+            msg = "No structure loaded. Please load a PDB/CIF file before running DSSR-PyMOL"
+            self.list_widget.addItem("Please load a PDB/CIF file before running DSSR-PyMOL")
+            self.status_label.setText(msg)
+            return
+
         self.list_widget.addItem('loading...')
         QtWidgets.QApplication.processEvents()
 
@@ -2130,15 +2138,26 @@ def dssr_gui():
     global _DSSR_GUI_DIALOG
     if QtWidgets is None or QtCore is None:
         raise CmdException('Qt is not available in this PyMOL build')
-    
-    if not cmd.get_object_list():
-        print("No structure loaded. Please load a PDB.CIF file before running DSSR-PyMOL")
-        return
+
+    # Check if a structure is available before showing GUI or running DSSR
+    no_struct = not cmd.get_object_list()
+
     if _DSSR_GUI_DIALOG is None:
         _DSSR_GUI_DIALOG = _DSSRGuiDialog()
     _DSSR_GUI_DIALOG.show()
     _DSSR_GUI_DIALOG.raise_()
     _DSSR_GUI_DIALOG.activateWindow()
+
+    # Visual pop-up dialog warning and console diagnostic print if no structure is available
+    if no_struct:
+        msg = "No structure loaded. Please load a PDB/CIF file before running DSSR-PyMOL"
+        print(msg)
+        _DSSR_GUI_DIALOG.status_label.setText(msg)
+        QtWidgets.QMessageBox.warning(
+            _DSSR_GUI_DIALOG,
+            "No Structure Loaded",
+            msg
+        )
 
 def __init_plugin__(app=None):
     from pymol.plugins import addmenuitemqt


### PR DESCRIPTION
The updated dssr_select.py script does not raise an error when a user tries to run the dssr_gui command without a selected structure, but rather it provides them with a helpful message to instruct them to input a structure. This makes the tool more professional and adapted for users. 